### PR TITLE
Avoid player collision (maximum one robot at any given map position)

### DIFF
--- a/backend/src/main/kotlin/xyz/poeschl/pathseeker/exceptions/RobotException.kt
+++ b/backend/src/main/kotlin/xyz/poeschl/pathseeker/exceptions/RobotException.kt
@@ -3,6 +3,8 @@ package xyz.poeschl.pathseeker.exceptions
 import org.springframework.http.HttpStatus
 import org.springframework.web.server.ResponseStatusException
 
-class MoveOutOfMapException(message: String) : ResponseStatusException(HttpStatus.NOT_ACCEPTABLE, message)
+class PositionOutOfMapException(message: String) : ResponseStatusException(HttpStatus.NOT_ACCEPTABLE, message)
 
 class InsufficientFuelException(message: String) : ResponseStatusException(HttpStatus.REQUESTED_RANGE_NOT_SATISFIABLE, message)
+
+class PositionNotAllowedException(message: String) : ResponseStatusException(HttpStatus.CONFLICT, message)


### PR DESCRIPTION
Added check of position when creating and/or moving a robot, if the position is already occupied by another robot, an exception _PositionNotAllowedException_ is thrown.
_MoveOutOfMapException_ renamed to _PositionOutOfMapException_ so we can use it both for creation and move.