### PR TITLE
Use custom build jre for backend image

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,7 +1,50 @@
-FROM eclipse-temurin:17-jdk-alpine
+# Use jdk 18 to analyze dependencies bacause jdeps from JDK 17 has a bug
+FROM  docker.io/eclipse-temurin:18-jdk-alpine as detect-deps
 
+COPY build/libs/backend-*.jar /app/app.jar
+
+RUN mkdir /app/unpacked && \
+    cd /app/unpacked && \
+    unzip ../app.jar && \
+    cd .. && \
+    $JAVA_HOME/bin/jdeps \
+    --ignore-missing-deps \
+    --print-module-deps \
+    -q \
+    --recursive \
+    --multi-release 17 \
+    --class-path="./unpacked/BOOT-INF/lib/*" \
+    --module-path="./unpacked/BOOT-INF/lib/*" \
+    ./app.jar > /deps.info && \
+    cat /deps.info
+
+FROM  docker.io/eclipse-temurin:17-jdk-alpine as slim-jre
+
+RUN apk add --no-cache binutils
+COPY --from=detect-deps /deps.info /deps.info
+RUN $JAVA_HOME/bin/jlink \
+    --verbose \
+    --add-modules $(cat /deps.info) \
+    --strip-debug \
+    --no-man-pages \
+    --no-header-files \
+    --compress=2 \
+    --output /slim-jre
+
+FROM docker.io/alpine:3.19 as application
+ENV JAVA_HOME=/jre
+ENV PATH="${JAVA_HOME}/bin:${PATH}"
+
+COPY --from=slim-jre /slim-jre $JAVA_HOME
+
+# Add dedicated user for non-root run
+ARG APPLICATION_USER=java
+RUN adduser --no-create-home -u 1000 -D $APPLICATION_USER && \
+    mkdir /app && chown -R $APPLICATION_USER /app
+USER 1000
 WORKDIR /app
+
 ENTRYPOINT ["java", "-jar", "/app/pathseeker-backend.jar"]
 EXPOSE 8080
 
-ADD build/libs/backend-*.jar /app/pathseeker-backend.jar
+COPY --chown=1000:1000 build/libs/backend-*.jar /app/pathseeker-backend.jar


### PR DESCRIPTION
I ran some tests with different docker java images and got following size results for the final size of the docker image.

* JDK 17: (the one before this PR): 378 MB
* JRE 17: 240 MB
* Custom built JRE with only used Java modules: 127 MB

The compiled Java artefact is 63 MB for it self. So I'm going for the custom built JRE in this PR.

During the docker build the java artifact is getting scanned by `jdeps` and the used jdk modules are transfered to jlink, which then creates a slimmed-down JRE for us to use.

closes #37 