### PR TITLE
:recycle: Allow free rolling down for robots

### DIFF
--- a/backend/src/main/kotlin/xyz/poeschl/pathseeker/gamelogic/internal/MapHandler.kt
+++ b/backend/src/main/kotlin/xyz/poeschl/pathseeker/gamelogic/internal/MapHandler.kt
@@ -5,7 +5,6 @@ import xyz.poeschl.pathseeker.configuration.GameLogic
 import xyz.poeschl.pathseeker.models.*
 import xyz.poeschl.pathseeker.models.Map
 import java.util.stream.IntStream
-import kotlin.math.abs
 import kotlin.math.ceil
 import kotlin.random.Random
 import kotlin.streams.toList
@@ -91,7 +90,8 @@ class MapHandler {
   }
 
   fun getFuelCost(oldPosition: Position, newPosition: Position): Int {
-    return STATIC_FUEL_COST + abs(getTileAtPosition(oldPosition).height - getTileAtPosition(newPosition).height)
+    // Rolling down a hill cost no extra fuel
+    return STATIC_FUEL_COST + (getTileAtPosition(newPosition).height - getTileAtPosition(oldPosition).height).coerceAtLeast(0)
   }
 
   /**

--- a/backend/src/test/kotlin/xyz/poeschl/pathseeker/gamelogic/internal/MapHandlerTest.kt
+++ b/backend/src/test/kotlin/xyz/poeschl/pathseeker/gamelogic/internal/MapHandlerTest.kt
@@ -76,7 +76,22 @@ class MapHandlerTest {
     val fuel = mapHandler.getFuelCost(Position(0, 0), Position(0, 1))
 
     // VERIFY
-    assertThat(fuel).isEqualTo(3) // (3-1) + 1
+    assertThat(fuel).isEqualTo(3) // max((3-1),0) + 1
+  }
+
+  @Test
+  fun getFuelCost_freeRolling() {
+    // WHEN
+    // Map:
+    // 1 2
+    // 3 4
+    mapHandler.createNewPresetMap(Size(2, 2), listOf(1, 2, 3, 4), Position(0, 0))
+
+    // THEN
+    val fuel = mapHandler.getFuelCost(Position(1, 1), Position(1, 0))
+
+    // VERIFY
+    assertThat(fuel).isEqualTo(1) // max((2-4), 0) + 1
   }
 
   @Test


### PR DESCRIPTION
This will change the fuel calculation of robot movements to free rolling down of a hill.

height 2 -> height 4 = 3 fuel = (4-2) + 1

height 4 -> height 2 = 1 fuel (only static movement cost)

What do you think @cramosk :)