### PR TITLE
:bug: Fix black map on map reload.

### DIFF
--- a/backend/src/main/kotlin/xyz/poeschl/roborush/controller/ConfigRestController.kt
+++ b/backend/src/main/kotlin/xyz/poeschl/roborush/controller/ConfigRestController.kt
@@ -68,7 +68,10 @@ class ConfigRestController(private val configService: ConfigService, private val
   @PreAuthorize("hasRole('${User.ROLE_ADMIN}')")
   @GetMapping("/map", produces = [MediaType.APPLICATION_JSON_VALUE])
   fun getMaps(): List<PlaygroundMap> {
-    return mapService.getAllMaps().map { PlaygroundMap(it) }
+    return mapService.getAllMaps().map {
+      val minMax = Pair(it.mapData.minOf { mapTile -> mapTile.height }, it.mapData.maxOf { mapTile -> mapTile.height })
+      return@map PlaygroundMap(it, minMax)
+    }
   }
 
   @SecurityRequirement(name = "Bearer Authentication")
@@ -78,7 +81,8 @@ class ConfigRestController(private val configService: ConfigService, private val
     val map = mapService.getMap(id)
 
     if (map != null) {
-      return PlaygroundMap(mapService.setMapActive(map, activeDto.active))
+      val minMax = Pair(map.mapData.minOf { it.height }, map.mapData.maxOf { it.height })
+      return PlaygroundMap(mapService.setMapActive(map, activeDto.active), minMax)
     } else {
       throw MapNotFound("No matching map found for setting active")
     }
@@ -91,7 +95,8 @@ class ConfigRestController(private val configService: ConfigService, private val
     val map = mapService.getMap(id)
 
     if (map != null) {
-      return PlaygroundMap(mapService.setMapAttributes(map, attributes))
+      val minMax = Pair(map.mapData.minOf { it.height }, map.mapData.maxOf { it.height })
+      return PlaygroundMap(mapService.setMapAttributes(map, attributes), minMax)
     } else {
       throw MapNotFound("No matching map found for given id.")
     }

--- a/backend/src/main/kotlin/xyz/poeschl/roborush/controller/GameRestController.kt
+++ b/backend/src/main/kotlin/xyz/poeschl/roborush/controller/GameRestController.kt
@@ -18,7 +18,7 @@ class GameRestController(private val gameHandler: GameHandler) {
 
   @GetMapping("/map", produces = [MediaType.APPLICATION_JSON_VALUE])
   fun getMap(): PlaygroundMap {
-    return PlaygroundMap(gameHandler.getCurrentMap())
+    return PlaygroundMap(gameHandler.getCurrentMap(), gameHandler.getCurrentMapHeightMetadata())
   }
 
   @Operation(

--- a/backend/src/main/kotlin/xyz/poeschl/roborush/controller/restmodels/MapDtos.kt
+++ b/backend/src/main/kotlin/xyz/poeschl/roborush/controller/restmodels/MapDtos.kt
@@ -25,7 +25,7 @@ data class PlaygroundMap(
   val maxHeight: Int
 ) {
 
-  constructor(map: Map) : this(
+  constructor(map: Map, minMax: Pair<Int, Int>) : this(
     map.id!!,
     map.mapName,
     map.size,
@@ -35,7 +35,7 @@ data class PlaygroundMap(
     map.solarChargeRate,
     map.active,
     map.mapData,
-    minHeight = map.mapData.minOf { it.height },
-    maxHeight = map.mapData.maxOf { it.height }
+    minMax.first,
+    minMax.second
   )
 }

--- a/backend/src/main/kotlin/xyz/poeschl/roborush/gamelogic/GameHandler.kt
+++ b/backend/src/main/kotlin/xyz/poeschl/roborush/gamelogic/GameHandler.kt
@@ -45,6 +45,10 @@ class GameHandler(
     return mapHandler.getMapWithPositions(getGlobalKnownPositions())
   }
 
+  fun getCurrentMapHeightMetadata(): Pair<Int, Int> {
+    return mapHandler.getMapHeightMetaData()
+  }
+
   fun getTileAtPosition(position: Position): Tile {
     return mapHandler.getTileAtPosition(position)
   }

--- a/backend/src/main/kotlin/xyz/poeschl/roborush/gamelogic/internal/MapHandler.kt
+++ b/backend/src/main/kotlin/xyz/poeschl/roborush/gamelogic/internal/MapHandler.kt
@@ -42,6 +42,10 @@ class MapHandler {
     return reducedMap
   }
 
+  fun getMapHeightMetaData(): Pair<Int, Int> {
+    return Pair(currentMap.mapData.minOf { it.height }, currentMap.mapData.maxOf { it.height })
+  }
+
   fun getStartPositions(): List<Position> {
     return currentMap.possibleStartPositions
   }


### PR DESCRIPTION
When loading a new map from the backend the min and max tile height based on the target tile only (now other, because no tile was stepped on). So the map canvas know only one height an the logic to color tiles was messed up.

closes #192