### PR TITLE
Potential fix for code scanning alert no. 68: Use of a potentially broken or risky cryptographic algorithm

### DIFF
--- a/backend/src/main/kotlin/xyz/poeschl/roborush/security/utils/JwtTokenProvider.kt
+++ b/backend/src/main/kotlin/xyz/poeschl/roborush/security/utils/JwtTokenProvider.kt
@@ -33,7 +33,7 @@ class JwtTokenProvider {
 
   init {
     val decodedKey = Sha512DigestUtils.sha(jwtSecretSource)
-    key = SecretKeySpec(decodedKey, 0, decodedKey.size, "HMACSHA512")
+    key = SecretKeySpec(decodedKey, 0, decodedKey.size, "HmacSHA512")
   }
 
   // Without expire right now!


### PR DESCRIPTION
Potential fix for [https://github.com/Poeschl/RoboRush/security/code-scanning/68](https://github.com/Poeschl/RoboRush/security/code-scanning/68)

To fix the flagged issue, we must ensure that the key used for JWT signing is instantiated with a supported and standard algorithm name. The current `"HMACSHA512"` string in `SecretKeySpec` should be replaced with `"HmacSHA512"`, as this is the canonical and supported Java cryptography algorithm name for HMAC with SHA-512.

The fix involves:
- Locating the line that calls `SecretKeySpec(decodedKey, 0, decodedKey.size, "HMACSHA512")`
- Changing `"HMACSHA512"` to `"HmacSHA512"`

This change only affects the algorithm name passed to the key specification, and ensures interoperability with Java cryptography and JWT libraries. No further changes are needed, as the remainder of the code uses the key correctly for signing.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
